### PR TITLE
Update controller stub to new structure

### DIFF
--- a/src/Generators/stubs/controller.stub
+++ b/src/Generators/stubs/controller.stub
@@ -3,7 +3,7 @@
 namespace {{namespace}};
 
 use Illuminate\Http\Request;
-use {{foundation_namespace}}\Http\Controllers\Controller;
+use {{foundation_namespace}}\Http\Controller;
 
 class {{controller}} extends Controller
 {


### PR DESCRIPTION
The controllers folder got removed from the foundation folder and the controller moved straight into http.
