### PR TITLE
Lucid config file

### DIFF
--- a/config/lucid.php
+++ b/config/lucid.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+    /*
+     |--------------------------------------------------------------------------
+     | Dashboard
+     |--------------------------------------------------------------------------
+     |
+     | By default /lucid/dashboard is avilable on when env('APP_DEBUG') is true.
+     | If you set this value to "true" it will be always accessable even on
+     | production environment.
+     |
+     */
+    'dashboard'     => null,
+
+    /*
+     |--------------------------------------------------------------------------
+     | Microservice
+     |--------------------------------------------------------------------------
+     |
+     | By default Lucid Architecture is setup as microservice. Microservice
+     | means that you will have only one service and all features / jobs / data
+     | etc. will be generated into /app/ directory.
+     |
+     | When you set this value to "false" it means you application have multiple
+     | services and all classes will be generated into /src/ directrory. After
+     | changing that value all "lucid" classes should be moved from /app/ to
+     | /src/.
+     */
+     //'microservice'  => true,
+
+];

--- a/config/lucid.php
+++ b/config/lucid.php
@@ -6,9 +6,9 @@ return [
      | Dashboard
      |--------------------------------------------------------------------------
      |
-     | By default /lucid/dashboard is avilable on when env('APP_DEBUG') is true.
-     | If you set this value to "true" it will be always accessable even on
-     | production environment.
+     | By default /lucid/dashboard is available on when env('APP_DEBUG')
+     | is true. If you set this value to "true" it will be always accessible
+     | even on production environment.
      |
      */
     'dashboard'     => null,
@@ -23,9 +23,10 @@ return [
      | etc. will be generated into /app/ directory.
      |
      | When you set this value to "false" it means you application have multiple
-     | services and all classes will be generated into /src/ directrory. After
-     | changing that value all "lucid" classes should be moved from /app/ to
-     | /src/.
+     | services and all classes will be generated into /src/ directrory.
+     | After changing that value all "lucid" classes should be moved
+     | from /app/ to /src/.
+     |
      */
      //'microservice'  => true,
 

--- a/config/lucid.php
+++ b/config/lucid.php
@@ -6,28 +6,10 @@ return [
      | Dashboard
      |--------------------------------------------------------------------------
      |
-     | By default /lucid/dashboard is available on when env('APP_DEBUG')
-     | is true. If you set this value to "true" it will be always accessible
-     | even on production environment.
+     | By default /lucid/dashboard is available when env('APP_DEBUG') is true.
+     | If you set this value to "true" it will be always accessible even on
+     | production environment.
      |
      */
     'dashboard'     => null,
-
-    /*
-     |--------------------------------------------------------------------------
-     | Microservice
-     |--------------------------------------------------------------------------
-     |
-     | By default Lucid Architecture is setup as microservice. Microservice
-     | means that you will have only one service and all features / jobs / data
-     | etc. will be generated into /app/ directory.
-     |
-     | When you set this value to "false" it means you application have multiple
-     | services and all classes will be generated into /src/ directrory.
-     | After changing that value all "lucid" classes should be moved
-     | from /app/ to /src/.
-     |
-     */
-     //'microservice'  => true,
-
 ];

--- a/src/LucidServiceProvider.php
+++ b/src/LucidServiceProvider.php
@@ -24,8 +24,19 @@ class LucidServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (!$this->app->routesAreCached()) {
-            require_once __DIR__.'/Http/routes.php';
+        $configPath = __DIR__ . '/../config/lucid.php';
+        $this->publishes([$configPath => $this->getConfigPath()], 'config');
+
+        $dashboard_enabled = $this->app['config']->get('lucid.dashboard');
+
+        if ($dashboard_enabled === null) {
+            $dashboard_enabled = $this->app['config']->get('app.debug');
+        }
+
+        if ($dashboard_enabled === true) {
+            if (!$this->app->routesAreCached() ) {
+                require_once __DIR__.'/Http/routes.php';
+            }
         }
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'lucid');
@@ -40,6 +51,19 @@ class LucidServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $configPath = __DIR__ . '/../config/lucid.php';
+        $this->mergeConfigFrom($configPath, 'lucid');
+
         $this->app->register(LogReaderServiceProvider::class);
+    }
+
+    /**
+     * Return path to config file.
+     *
+     * @return string
+     */
+    private function getConfigPath()
+    {
+        return config_path('lucid.php');
     }
 }

--- a/src/LucidServiceProvider.php
+++ b/src/LucidServiceProvider.php
@@ -27,13 +27,13 @@ class LucidServiceProvider extends ServiceProvider
         $configPath = __DIR__ . '/../config/lucid.php';
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
 
-        $dashboard_enabled = $this->app['config']->get('lucid.dashboard');
+        $dashboardEnabled = $this->app['config']->get('lucid.dashboard');
 
-        if ($dashboard_enabled === null) {
-            $dashboard_enabled = $this->app['config']->get('app.debug');
+        if ($dashboardEnabled === null) {
+            $dashboardEnabled = $this->app['config']->get('app.debug');
         }
 
-        if ($dashboard_enabled === true) {
+        if ($dashboardEnabled === true) {
             if (!$this->app->routesAreCached() ) {
                 require_once __DIR__.'/Http/routes.php';
             }


### PR DESCRIPTION
By default /lucid/dashboard is accessible even on production environment and it can't be easily disabled. So I introduce lucid.php config. Config file can be copied to /config/lucid.php by standard `vendor:publish` command.

By default `dashboard` is null what means ServiceProvider will check `enc('APP_DEBUG')` and basing on this it will include `lucid/dashboard` or not. You can force to route show or not by changing value.

Next variable can be `microservice` boolean to switch Lucid Architecture. It's something that might be consider in future. Thanks to that you will not need `laravel` and `laravel-microservice` separated. 

