### PR TITLE
Turn possible to pass a list of jobs on the make:operation

### DIFF
--- a/src/Commands/OperationMakeCommand.php
+++ b/src/Commands/OperationMakeCommand.php
@@ -81,6 +81,7 @@ class OperationMakeCommand extends SymfonyCommand
         return [
             ['operation', InputArgument::REQUIRED, 'The operation\'s name.'],
             ['service', InputArgument::OPTIONAL, 'The service in which the operation should be implemented.'],
+            ['jobs', InputArgument::IS_ARRAY, 'A list of Jobs Operation calls']
         ];
     }
 


### PR DESCRIPTION
Turn possible to pass a list of jobs on the make:operation and create it
with all necessary "use" and "$this->run()" following the order of jobs
names.

Examples:

./vendor/bin/lucid make:operation DefaultStore  Deadline 'App\Domains\Common\Jobs\ValidateStoreJob' 'App\Domains\Common\Jobs\StoreJob'

Generating code below

<?php
namespace App\Services\Deadline\Operations;

use Lucid\Foundation\Operation;
use Illuminate\Http\Request;
use App\Domains\Common\Jobs\ValidateStoreJob;
use App\Domains\Common\Jobs\StoreJob;

class DefaultStoreOperation extends Operation
{
    public function handle(Request $request)
    {
$this->run(ValidateStoreJob::class);

$this->run(StoreJob::class);
    }
}