### PR TITLE
Fix namespacing rules for tests generators

### DIFF
--- a/src/Generators/stubs/operation.stub
+++ b/src/Generators/stubs/operation.stub
@@ -1,4 +1,5 @@
 <?php
+
 namespace {{namespace}};
 
 use {{foundation_namespace}}\Operation;


### PR DESCRIPTION
Fix namespacing for tests generators when executed in microservice context. The current convention is:

```
namespace App\Domains\Pokemons\Tests\Jobs;
```

Should be 

```
namespace Tests\Domains\Pokemons\Jobs;
```

Additionally, the missing empty line was added for Operation stub.