### PR TITLE
added better error handling for feature deletion

### DIFF
--- a/src/Commands/FeatureDeleteCommand.php
+++ b/src/Commands/FeatureDeleteCommand.php
@@ -60,7 +60,11 @@ class FeatureDeleteCommand extends SymfonyCommand
             $title = $this->parseName($this->argument('feature'));
 
             if (!$this->exists($feature = $this->findFeaturePath($service, $title))) {
-                $this->error('Feature class '.$title.' cannot be found.');
+                if($service != "") {
+                    $this->error('Feature class '.$title.' cannot be found.');
+                } else {
+                    $this->error('Couldn\'t find feature class. Maybe missing "service" argument?');
+                }
             } else {
                 $this->delete($feature);
 


### PR DESCRIPTION
I was using the delete:feature command and didn't understand why it "couldn't find the feature class" then I realized there was an optional service argument.
This should be handled better when the class can't be found in my opinion.